### PR TITLE
Revert "chore(deps): bump httpx from 0.22.0 to 0.23.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ emoji==1.7.0
 feedparser==6.0.10; python_version >= "3.7"
 h11==0.12.0; python_version >= "3.7"
 httpcore==0.14.7; python_version >= "3.7"
-httpx==0.23.0; python_version >= "3.7"
+httpx==0.22.0; python_version >= "3.7"
 idna==3.3; python_full_version >= "3.6.2" and python_version >= "3.7"
 iso8601==1.0.2; python_full_version >= "3.6.2" and python_version < "4.0" and python_version >= "3.7"
 loguru==0.6.0; python_version >= "3.5"


### PR DESCRIPTION
Reverts dbrennand/RSS_Feederbot#11

Causes installation issues:

```
#9 7.536 ERROR: Cannot install -r requirements.txt (line 12) and httpcore==0.14.7 because these package versions have conflicting dependencies.
#9 7.536
#9 7.536 The conflict is caused by:
#9 7.536     The user requested httpcore==0.14.7
#9 7.536     httpx 0.23.0 depends on httpcore<0.16.0 and >=0.15.0
```