### PR TITLE
docs: add Telegram bot token prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Feederbot checks on a user configurable interval for feed updates.
 
 ## Prerequisites
 
-1. Docker
+1. A Telegram bot token from [@BotFather](https://t.me/botfather)
+
+2. Docker
 
 ## Supported Commands
 


### PR DESCRIPTION
Add missing prerequisite to README to have a Telegram bot token.